### PR TITLE
EPIC - 1997 - Permission handling, SDK initialisation Und iOS Bug Fix

### DIFF
--- a/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer.Android/MainActivity.cs
+++ b/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer.Android/MainActivity.cs
@@ -15,7 +15,7 @@ namespace NativeBarcodeSDKRenderer.Droid
         protected override void OnCreate(Bundle savedInstanceState)
         {
             base.OnCreate(savedInstanceState);
-
+            ScanbotBarcodeSDK.Forms.Droid.DependencyManager.Register();
             Xamarin.Essentials.Platform.Init(this, savedInstanceState);
             global::Xamarin.Forms.Forms.Init(this, savedInstanceState);
 

--- a/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer.Android/MainApplication.cs
+++ b/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer.Android/MainApplication.cs
@@ -32,14 +32,6 @@ namespace NativeBarcodeSDKRenderer.Droid
             base.OnCreate();
 
             operations = new ScanbotOperations();
-
-            Log.Debug(LOG_TAG, "Initializing Scanbot SDK...");
-            var initializer = new ScanbotBarcodeScannerSDKInitializer();
-            initializer.WithLogging(true, enableNativeLogging: false);
-            initializer.UseCameraXRtuUi(false);
-            initializer.License(this, ScanbotSDKConfiguration.LICENSE_KEY);
-            initializer.Initialize(this);
-
             operations.ClearStorageDirectory();
         }
     }

--- a/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer.iOS/AppDelegate.cs
+++ b/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer.iOS/AppDelegate.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 
 using Foundation;
+using NativeBarcodeSDKRenderer.Common;
+using ScanbotBarcodeSDK.iOS;
 using UIKit;
 
 namespace NativeBarcodeSDKRenderer.iOS
@@ -22,9 +24,11 @@ namespace NativeBarcodeSDKRenderer.iOS
         //
         public override bool FinishedLaunching(UIApplication app, NSDictionary options)
         {
+            // Most important line, else the Forms objects won't work.
+            ScanbotBarcodeSDK.Forms.iOS.DependencyManager.Register();
             global::Xamarin.Forms.Forms.Init();
             LoadApplication(new App());
-
+            Xamarin.Essentials.Platform.Init(() => Window.RootViewController);
             return base.FinishedLaunching(app, options);
         }
     }

--- a/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer/App.xaml.cs
+++ b/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer/App.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using ScanbotBarcodeSDK.Forms;
 using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
@@ -11,6 +12,19 @@ namespace NativeBarcodeSDKRenderer
             InitializeComponent();
 
             MainPage = new MainPage();
+
+            var options = new InitializationOptions
+            {
+                LicenseKey = Common.ScanbotSDKConfiguration.LICENSE_KEY,
+                LoggingEnabled = true,
+                UseCameraXRtuUi = false,
+                ErrorHandler = (status, feature) =>
+                {
+                    Console.WriteLine($"License error: {status}, {feature}");
+                }
+            };
+            SBSDK.Initialize(options);
+            Console.WriteLine(SBSDK.LicenseInfo);
         }
 
         protected override void OnStart ()

--- a/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer/MainPage.xaml.cs
+++ b/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer/MainPage.xaml.cs
@@ -148,7 +148,7 @@ namespace NativeBarcodeSDKRenderer
             safeInsets.Bottom = 0;
             Padding = safeInsets;
 
-            // In iOS the cameraView doesn't stops scanning so below button is kind of useless.
+            // In iOS the cameraView doesn't support pausing so we hide the button.
             buttonsLayout.IsVisible = false;
         }
 

--- a/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer/MainPage.xaml.cs
+++ b/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer/MainPage.xaml.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 using NativeBarcodeSDKRenderer.Common;
 using ScanbotBarcodeSDK.Forms;
+using Xamarin.Essentials;
 using Xamarin.Forms;
 using Xamarin.Forms.PlatformConfiguration;
 using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
@@ -14,28 +15,40 @@ namespace NativeBarcodeSDKRenderer
 {
     public partial class MainPage : ContentPage
     {
+
         private bool isDetectionOn;
+        /// <summary>
+        /// Is Detection is On or Off
+        /// </summary>
         private bool IsDetectionOn
         {
             get => isDetectionOn;
             set
             {
                 isDetectionOn = value;
-                scanButton.Text = value ? "STOP SCANNING" : "START SCANNING";
-                RefreshCamera();
+                MainThread.BeginInvokeOnMainThread(() => ToggleUIOnScanning(value));
             }
         }
 
+        /// <summary>
+        /// Get the License of the SDK.
+        /// </summary>
+        private bool IsLicenseValid => SBSDK.LicenseInfo.IsValid;
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
         public MainPage()
         {
             InitializeComponent();
             SetupViews();
         }
 
+        /// <summary>
+        /// Set Up UI on initial launch
+        /// </summary>
         private void SetupViews()
         {
-            IsDetectionOn = false;
-
             cameraView.OnBarcodeScanResult = (result) =>
             {
                 string text = "";
@@ -49,40 +62,61 @@ namespace NativeBarcodeSDKRenderer
                     resultsLabel.Text = text;
                 });
             };
+            SetupIOSAppearance();
         }
 
-        protected override void OnAppearing()
+        /// <summary>
+        /// OnAppearing - Invoked on every Page forground
+        /// </summary>
+        async protected override void OnAppearing()
         {
             base.OnAppearing();
-
-            RefreshCamera();
-
-            SetupIOSAppearance();
 
             scanButton.Clicked += OnScanButtonPressed;
             infoButton.Clicked += OnInfoButtonPressed;
 
-            cameraView.Resume();
-
-            if (ScanbotSDKConfiguration.LICENSE_KEY.Equals(""))
+            if (!await CameraPermissionAllowed())
             {
-                ShowTrialLicenseAlert();
+                IsDetectionOn = false;
+            }
+            else
+            {
+                if (ScanbotSDKConfiguration.LICENSE_KEY.Equals(""))
+                {
+                    await ShowTrialLicenseAlert();
+                }
+
+                ToggleUIOnScanning(IsDetectionOn); // Update UI with IsDetection flag status
             }
         }
 
+        /// <summary>
+        /// OnDisappearing - Invoked on every Page background
+        /// </summary>
         protected override void OnDisappearing()
         {
             base.OnDisappearing();
 
             scanButton.Clicked -= OnScanButtonPressed;
             infoButton.Clicked -= OnInfoButtonPressed;
-
-            cameraView.Pause();
+            if (IsDetectionOn)
+            {
+                cameraView.StopDetection();
+            }
         }
 
-        private void OnScanButtonPressed(object sender, EventArgs e)
+        /// <summary>
+        /// Scanning Button click event
+        /// Checks for Camera Permission, License and invokes scanning feature.
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private async void OnScanButtonPressed(object sender, EventArgs e)
         {
-            if (!SBSDK.LicenseInfo.IsValid)
+            if (!await CameraPermissionAllowed())
+                return;
+
+            if (!IsLicenseValid)
             {
                 ShowExpiredLicenseAlert();
                 return;
@@ -91,21 +125,9 @@ namespace NativeBarcodeSDKRenderer
             IsDetectionOn = !IsDetectionOn;
         }
 
-        private void RefreshCamera()
-        {
-            if (IsDetectionOn)
-            {
-                cameraView.StartDetection();
-            }
-            else
-            {
-                cameraView.StopDetection();
-            }
-        }
-
         private void OnInfoButtonPressed(object sender, EventArgs e)
         {
-            DisplayAlert("Info", SBSDK.LicenseInfo.IsValid ? "Your SDK License is valid." : "Your SDK License has expired.", "Close");
+            DisplayAlert("Info", IsLicenseValid ? "Your SDK License is valid." : "Your SDK License has expired.", "Close");
         }
 
         private void ShowExpiredLicenseAlert()
@@ -113,9 +135,9 @@ namespace NativeBarcodeSDKRenderer
             DisplayAlert("Error", "Your SDK license has expired", "Close");
         }
 
-        private void ShowTrialLicenseAlert()
+        async private Task ShowTrialLicenseAlert()
         {
-            DisplayAlert("Welcome", "You are using the Trial SDK License. The SDK will be active for one minute.", "Close");
+            await DisplayAlert("Welcome", "You are using the Trial SDK License. The SDK will be active for one minute.", "Close");
         }
 
         private void SetupIOSAppearance()
@@ -126,8 +148,73 @@ namespace NativeBarcodeSDKRenderer
             safeInsets.Bottom = 0;
             Padding = safeInsets;
 
-            resultsPreviewLayout.BackgroundColor = Color.White;
+            // In iOS the cameraView doesn't stops scanning so below button is kind of useless.
             buttonsLayout.IsVisible = false;
+        }
+
+        /// <summary>
+        /// Toggle UI on the scanning On/Off.
+        /// </summary>
+        /// <param name="isDetectionOn"></param>
+        private void ToggleUIOnScanning(bool isDetectionOn)
+        {
+            if (isDetectionOn)
+            {
+                cameraView.StartDetection();
+                scanButton.Text = "STOP SCANNING";
+                resultsPreviewLayout.BackgroundColor = Color.White;
+            }
+            else
+            {
+                scanButton.Text = "START SCANNING";
+                resultsPreviewLayout.BackgroundColor = Color.FromHex("#d2d2d2");
+                cameraView.StopDetection();
+            }
+        }
+
+
+        /// <summary>
+        /// Check for Camera permissions.
+        /// </summary>
+        /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
+        private async Task<bool> CameraPermissionAllowed()
+        {
+            var isAllowed = false;
+            var status = await Permissions.CheckStatusAsync<Permissions.Camera>();
+            switch (status)
+            {
+                case PermissionStatus.Unknown:  // Defult permission status For iOS is Unknown
+                    {
+                        await Permissions.RequestAsync<Permissions.Camera>();
+                        isAllowed = await Permissions.CheckStatusAsync<Permissions.Camera>() == PermissionStatus.Granted;
+                    }
+                    break;
+
+                case PermissionStatus.Denied: // Default permission status for Android is Denied
+                    if (DeviceInfo.Platform == DevicePlatform.Android)
+                    {
+                        status = await Permissions.RequestAsync<Permissions.Camera>();
+                        isAllowed = await Permissions.CheckStatusAsync<Permissions.Camera>() == PermissionStatus.Granted;
+                    }
+
+                    if (!isAllowed)
+                    {
+                        await DisplayAlert("Alert", "Please turn on the camera permissions from setting screen, to turn on scanning feature.", "Ok");
+                    }
+                    break;
+
+                case PermissionStatus.Disabled:
+                    break;
+
+                case PermissionStatus.Granted:
+                    isAllowed = true;
+                    break;
+
+                case PermissionStatus.Restricted:
+                    break;
+            }
+            return isAllowed;
         }
     }
 }

--- a/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer.csproj
+++ b/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer.csproj
@@ -14,7 +14,6 @@
     <PackageReference Include="Xamarin.Forms" Version="5.0.0.2478" />
     <PackageReference Include="Xamarin.Essentials" Version="1.7.3" />
     <PackageReference Include="ScanbotBarcodeSDK.Xamarin.Forms" Version="3.2.0" />
-    <PackageReference Include="ScanbotBarcodeSDK.Xamarin" Version="3.2.0" />
   </ItemGroup>
   <ItemGroup>
     <None Remove="Common\" />

--- a/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer.csproj
+++ b/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer.csproj
@@ -14,11 +14,13 @@
     <PackageReference Include="Xamarin.Forms" Version="5.0.0.2478" />
     <PackageReference Include="Xamarin.Essentials" Version="1.7.3" />
     <PackageReference Include="ScanbotBarcodeSDK.Xamarin.Forms" Version="3.2.0" />
+    <PackageReference Include="ScanbotBarcodeSDK.Xamarin" Version="3.2.0" />
   </ItemGroup>
   <ItemGroup>
     <None Remove="Common\" />
     <None Remove="Views\" />
     <None Remove="ScanbotBarcodeSDK.Xamarin.Forms" />
+    <None Remove="ScanbotBarcodeSDK.Xamarin" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Common\" />


### PR DESCRIPTION
- [x] Common - SDK init moved to the Common for both iOS and Android
- [x] iOS - Camera permission prompted before hitting the SDK scanning
- [x] Android/iOS - Added the dependencyRegister method at  Native initialisation.