### PR TITLE
EPIC - 2832 - Xamarin Barcode SDK update 3.3.1-beta4

### DIFF
--- a/Example.Forms/ScanbotBarcodeSDKFormsExample.Android/ScanbotBarcodeSDKFormsExample.Android.csproj
+++ b/Example.Forms/ScanbotBarcodeSDKFormsExample.Android/ScanbotBarcodeSDKFormsExample.Android.csproj
@@ -61,7 +61,7 @@
       <Version>1.7.4</Version>
     </PackageReference>
     <PackageReference Include="ScanbotBarcodeSDK.Xamarin.Forms">
-      <Version>3.3.1-beta3</Version>
+      <Version>3.3.1-beta4</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/Example.Forms/ScanbotBarcodeSDKFormsExample.iOS/ScanbotBarcodeSDKFormsExample.iOS.csproj
+++ b/Example.Forms/ScanbotBarcodeSDKFormsExample.iOS/ScanbotBarcodeSDKFormsExample.iOS.csproj
@@ -130,7 +130,7 @@
       <Version>0.0.2-beta1</Version>
     </PackageReference>
     <PackageReference Include="ScanbotBarcodeSDK.Xamarin.Forms">
-      <Version>3.3.1-beta3</Version>
+      <Version>3.3.1-beta4</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />

--- a/Example.Forms/ScanbotBarcodeSDKFormsExample/BarcodeResultsPage.cs
+++ b/Example.Forms/ScanbotBarcodeSDKFormsExample/BarcodeResultsPage.cs
@@ -98,6 +98,7 @@ namespace ScanbotBarcodeSDKFormsExample
             List = new ListView();
             List.ItemTemplate = new DataTemplate(typeof(BarcodeCell));
             List.RowHeight = ROWHEIGHT;
+            List.HasUnevenRows = true;
             List.ItemsSource = Barcodes;
         }
 

--- a/Example.Forms/ScanbotBarcodeSDKFormsExample/MainPage.cs
+++ b/Example.Forms/ScanbotBarcodeSDKFormsExample/MainPage.cs
@@ -131,16 +131,13 @@ namespace ScanbotBarcodeSDKFormsExample
                     List<Barcode> codes = null;
                     try
                     {
-                        var configuration = new DetectBarcodesOnImageConfiguration
-                        {
-                            Source = source,
-                            AcceptedDocumentFormats = new List<BarcodeDocumentFormat>(),
-                            AcceptedFormats = BarcodeTypes.Instance.AcceptedTypes,
-                            CodeDensity = BarcodeDensity.High,
-                            EngineMode = EngineMode.NextGen,
-                            LowPowerMode = true
-                        };
-                        codes = await SBSDK.Operations.DetectBarcodesFrom(configuration);
+                        var configuration = new DetectBarcodesOnImageConfiguration(source);
+                        configuration.AcceptedDocumentFormats = new List<BarcodeDocumentFormat>();
+                        configuration.AcceptedFormats = BarcodeTypes.Instance.AcceptedTypes;
+                        configuration.CodeDensity = BarcodeDensity.High;
+                        configuration.EngineMode = EngineMode.NextGen;
+                        configuration.LowPowerMode = true;
+                        codes = await SBSDK.Operations.DetectBarcodesFromImage(configuration);
                     }
                     catch (Exception exception)
                     {

--- a/Example/Droid/BarcodeScannerExample.Droid.csproj
+++ b/Example/Droid/BarcodeScannerExample.Droid.csproj
@@ -157,7 +157,7 @@
       <Version>0.0.2-beta1</Version>
     </PackageReference>
     <PackageReference Include="ScanbotBarcodeSDK.Xamarin">
-      <Version>3.3.1-beta3</Version>
+      <Version>3.3.1-beta4</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="..\BarcodeScannerExample\BarcodeScannerExample.projitems" Label="Shared" Condition="Exists('..\BarcodeScannerExample\BarcodeScannerExample.projitems')" />

--- a/Example/iOS/BarcodeScannerExample.iOS.csproj
+++ b/Example/iOS/BarcodeScannerExample.iOS.csproj
@@ -82,13 +82,13 @@
       <HintPath>..\packages\Scanbot.Xamarin.ImagePicker.0.0.2-beta1\lib\Xamarin.iOS10\Scanbot.ImagePicker.iOS.dll</HintPath>
     </Reference>
     <Reference Include="ScanbotBarcodeSDK.iOS">
-      <HintPath>..\packages\ScanbotBarcodeSDK.Xamarin.3.3.1-beta3\lib\Xamarin.iOS10\ScanbotBarcodeSDK.iOS.dll</HintPath>
+      <HintPath>..\packages\ScanbotBarcodeSDK.Xamarin.3.3.1-beta4\lib\Xamarin.iOS10\ScanbotBarcodeSDK.iOS.dll</HintPath>
     </Reference>
     <Reference Include="ScanbotBarcodeSDK.Xamarin">
-      <HintPath>..\packages\ScanbotBarcodeSDK.Xamarin.3.3.1-beta3\lib\Xamarin.iOS10\ScanbotBarcodeSDK.Xamarin.dll</HintPath>
+      <HintPath>..\packages\ScanbotBarcodeSDK.Xamarin.3.3.1-beta4\lib\Xamarin.iOS10\ScanbotBarcodeSDK.Xamarin.dll</HintPath>
     </Reference>
     <Reference Include="ScanbotBarcodeSDK.Xamarin.iOS">
-      <HintPath>..\packages\ScanbotBarcodeSDK.Xamarin.3.3.1-beta3\lib\Xamarin.iOS10\ScanbotBarcodeSDK.Xamarin.iOS.dll</HintPath>
+      <HintPath>..\packages\ScanbotBarcodeSDK.Xamarin.3.3.1-beta4\lib\Xamarin.iOS10\ScanbotBarcodeSDK.Xamarin.iOS.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Example/iOS/Controllers/MainViewController.cs
+++ b/Example/iOS/Controllers/MainViewController.cs
@@ -186,10 +186,9 @@ namespace BarcodeScannerExample.iOS
             selectionOverlayConfiguration.PolygonColor = UIColor.Yellow;
             selectionOverlayConfiguration.TextContainerColor = UIColor.Black;
 
-            var configuration = new SBSDKUIBarcodeScannerConfiguration(uiConfiguration, textConfiguration, behaviourConfiguration, cameraConfiguration, selectionOverlayConfiguration);
-
             behaviourConfiguration.AcceptedMachineCodeTypes = BarcodeTypes.Instance.AcceptedTypes.ToArray();
-
+            behaviourConfiguration.AdditionalParameters = new SBSDKBarcodeAdditionalParameters { MinimumTextLength = 6 };
+            var configuration = new SBSDKUIBarcodeScannerConfiguration(uiConfiguration, textConfiguration, behaviourConfiguration, cameraConfiguration, selectionOverlayConfiguration);
             if (withImage)
             {
                 configuration.BehaviorConfiguration.BarcodeImageGenerationType =

--- a/Example/iOS/packages.config
+++ b/Example/iOS/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Scanbot.Xamarin.ImagePicker" version="0.0.2-beta1" targetFramework="xamarinios10" />
-  <package id="ScanbotBarcodeSDK.Xamarin" version="3.3.1-beta3" targetFramework="xamarinios10" />
+  <package id="ScanbotBarcodeSDK.Xamarin" version="3.3.1-beta4" targetFramework="xamarinios10" />
 </packages>

--- a/Libraries.txt
+++ b/Libraries.txt
@@ -1,4 +1,4 @@
-Open Source libraries used in the Scanbot Barcode Scanner SDK for iOS version 3.3.0:
+Open Source libraries used in the Scanbot Barcode Scanner SDK for iOS version 3.3.1:
 
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 

--- a/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer.Android/NativeBarcodeSDKRenderer.Android.csproj
+++ b/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer.Android/NativeBarcodeSDKRenderer.Android.csproj
@@ -56,10 +56,10 @@
     <PackageReference Include="Xamarin.Forms" Version="5.0.0.2545" />
     <PackageReference Include="Xamarin.Essentials" Version="1.7.4" />
     <PackageReference Include="ScanbotBarcodeSDK.Xamarin.Forms">
-      <Version>3.3.1-beta3</Version>
+      <Version>3.3.1-beta4</Version>
     </PackageReference>
     <PackageReference Include="ScanbotBarcodeSDK.Xamarin">
-      <Version>3.3.1-beta3</Version>
+      <Version>3.3.1-beta4</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer.iOS/NativeBarcodeSDKRenderer.iOS.csproj
+++ b/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer.iOS/NativeBarcodeSDKRenderer.iOS.csproj
@@ -128,10 +128,10 @@
     <PackageReference Include="Xamarin.Forms" Version="5.0.0.2545" />
     <PackageReference Include="Xamarin.Essentials" Version="1.7.4" />
     <PackageReference Include="ScanbotBarcodeSDK.Xamarin.Forms">
-      <Version>3.3.1-beta3</Version>
+      <Version>3.3.1-beta4</Version>
     </PackageReference>
     <PackageReference Include="ScanbotBarcodeSDK.Xamarin">
-      <Version>3.3.1-beta3</Version>
+      <Version>3.3.1-beta4</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />

--- a/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer.csproj
+++ b/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Xamarin.Forms" Version="5.0.0.2545" />
     <PackageReference Include="Xamarin.Essentials" Version="1.7.4" />
-    <PackageReference Include="ScanbotBarcodeSDK.Xamarin.Forms" Version="3.3.1-beta3" />
+    <PackageReference Include="ScanbotBarcodeSDK.Xamarin.Forms" Version="3.3.1-beta4" />
   </ItemGroup>
   <ItemGroup>
     <None Remove="Common\" />


### PR DESCRIPTION
- [x] Updated the beta versions in all the example projects to 3.3.1-beta4.
- [x] Updated the Libraries.txt file with version 3.3.1-beta4
- [x] Minor fix for list Item height in Example Forms project
- [x] Change of config in the forms project for DetectBarcodesOnImage