### PR TITLE
Xamarin Barcode SDK - Customer issue - To find Camera View

### DIFF
--- a/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer.Android/Renderers/AndroidBarcodeCameraRenderer.cs
+++ b/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer.Android/Renderers/AndroidBarcodeCameraRenderer.cs
@@ -146,7 +146,7 @@ namespace NativeBarcodeSDKRenderers.Droid.Renderers
                 barcodeDetectorFrameHandler = BarcodeDetectorFrameHandler.Attach(cameraView, detector);
 
                 detector.ModifyConfig(new Function1Impl<BarcodeScannerConfigBuilder>((response) => {
-                    response.SetSaveCameraPreviewFrame(true);
+                    response.SetSaveCameraPreviewFrame(false);
                 }));
 
                 if (barcodeDetectorFrameHandler is BarcodeDetectorFrameHandler handler)

--- a/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer.iOS/NativeBarcodeSDKRenderer.iOS.csproj
+++ b/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer.iOS/NativeBarcodeSDKRenderer.iOS.csproj
@@ -25,7 +25,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <MtouchArch>x86_64</MtouchArch>
-    <MtouchLink>None</MtouchLink>
+    <MtouchLink>SdkOnly</MtouchLink>
     <MtouchDebug>true</MtouchDebug>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">

--- a/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer/App.xaml.cs
+++ b/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer/App.xaml.cs
@@ -5,13 +5,22 @@ using Xamarin.Forms.Xaml;
 
 namespace NativeBarcodeSDKRenderer
 {
+    /// <summary>
+    /// Type of application.
+    /// </summary>
+    enum ApplicationType
+    {
+        SinglePage,
+        NavigationPage,
+        TabbedPage
+    }
+
     public partial class App : Application
     {
         public App ()
         {
             InitializeComponent();
-
-            MainPage = new MainPage();
+            MainPage = GetMainPage(applicationType: ApplicationType.TabbedPage);
 
             var options = new InitializationOptions
             {
@@ -38,6 +47,42 @@ namespace NativeBarcodeSDKRenderer
         protected override void OnResume ()
         {
         }
+
+        /// <summary>
+        /// Get the Application Main Page by selecting the structure mentioned.
+        /// </summary>
+        /// <param name="applicationType">Specify structure of the application</param>
+        /// <returns>Returns the page object</returns>
+        private Page GetMainPage(ApplicationType applicationType)
+        {
+            switch (applicationType)
+            {
+                case ApplicationType.SinglePage:
+                    return new MainPage();
+                case ApplicationType.NavigationPage:
+                    return new NavigationPage(new MainPage());
+                case ApplicationType.TabbedPage:
+                    var tabbedPage = new TabbedPage();
+                    tabbedPage.Children.Add(new MainPage { Title = "1"});
+                    tabbedPage.Children.Add(new SecondPage { Title = "2" });
+                    tabbedPage.Children.Add(new ThirdPage { Title = "3" });
+                    return tabbedPage;
+                default:
+                    return new MainPage();
+
+            }
+        }
+    }
+
+
+    public class SecondPage : ContentPage
+    {
+
+    }
+
+    public class ThirdPage : ContentPage
+    {
+
     }
 }
 

--- a/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer/MainPage.xaml.cs
+++ b/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer/NativeBarcodeSDKRenderer/MainPage.xaml.cs
@@ -147,9 +147,6 @@ namespace NativeBarcodeSDKRenderer
             var safeInsets = On<iOS>().SafeAreaInsets();
             safeInsets.Bottom = 0;
             Padding = safeInsets;
-
-            // In iOS the cameraView doesn't support pausing so we hide the button.
-            buttonsLayout.IsVisible = false;
         }
 
         /// <summary>


### PR DESCRIPTION
- [x] iOS - Start and Stop recognition added in iOS ( earlier there was no button like android start and stop scanning.)

- [x] Android - SetSaveCameraPreviewFrame is set to false. (earlier it was true)
- [x] iOS - BarcodeImageGenerationType - None --- (earlier it wasn’t set so it was by default None)
- [x] IOS/Android - I have added code for different types of app structures. user can just set enum and change the app structure to TabbedPage/NavigatoinPage/SinglePage. So they can get how to access the ViewController in all cases.